### PR TITLE
fix: index.d.ts now works with ts-node (and nodemon)  For ts-node (an…

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,5 +15,11 @@
   "exclude": [
     "node_modules",
     "<node_internals>/**",
-  ]
+  ],
+  "files":[
+    "src/index.d.ts"
+  ],
+  "ts-node": {
+    "files":true
+  }
 }


### PR DESCRIPTION
…d nodemon, ts-node-dev,...)

A decleration file has to be added to the "files" property of the ts-config.json 
Also files need to be enabled for ts-node

This fixes #34 