### PR TITLE
feat: add representant

### DIFF
--- a/hierarchical-image-explorer/src/components/Accumulator.svelte
+++ b/hierarchical-image-explorer/src/components/Accumulator.svelte
@@ -156,8 +156,8 @@
   /**
    * Takes a group of points and calculates the point closest to the center
    * @param input group within a hexagon
-   * @param x scaled x
-   * @param y scaled y
+   * @param x scaled to svg width
+   * @param y scaled to svg height
    */
   function getRepresentantImage(input: PointData[], x: number, y: number) {
     const cx = x + hexaSide;
@@ -166,14 +166,18 @@
     let representation = null;
     let minDistance = 10000000;
     let currentDistance;
-    
+
     input.forEach((p) => {
-      if((currentDistance = Math.sqrt(Math.pow(p.x - cx, 2) + Math.pow(p.y - cy, 2))) < minDistance){
-          minDistance = currentDistance;
-          representation = p;
+      if (
+        (currentDistance = Math.sqrt(
+          Math.pow(p.x - cx, 2) + Math.pow(p.y - cy, 2)
+        )) < minDistance
+      ) {
+        minDistance = currentDistance;
+        representation = p;
       }
-    })
-    return representation != null ? representation : input[0];  
+    });
+    return representation != null ? representation : input[0];
   }
 </script>
 
@@ -204,7 +208,13 @@
                 side={hexaSide}
                 x={scaleQuantisedX(x, y)}
                 y={scaleQuantisedY(y)}
-                image={BackendService.getImageUrl(getRepresentantImage(quantizedData[x][y], scaleQuantisedX(x,y), scaleQuantisedY(y)).id)}
+                image={BackendService.getImageUrl(
+                  getRepresentantImage(
+                    quantizedData[x][y],
+                    scaleQuantisedX(x, y),
+                    scaleQuantisedY(y)
+                  ).id
+                )}
                 strokeWidth={zoomLevel > lodBreakpoint ? 0.2 : 1}
                 stroke={zoomLevel > lodBreakpoint
                   ? ColorUtil.getCellColor(quantizedData[x][y])


### PR DESCRIPTION
A function to determine a representant for a group within a hexagon for better interpretability of the content.
![image](https://user-images.githubusercontent.com/69912534/172388315-eebeeeaf-4a67-4a47-b26d-451114217d3f.png)
