### PR TITLE
Initial zoom rendering fix

### DIFF
--- a/hierarchical-image-explorer/src/components/Accumulator.svelte
+++ b/hierarchical-image-explorer/src/components/Accumulator.svelte
@@ -64,7 +64,6 @@
     BackendService.getDataQuantized(initial_columns * 2 ** lod).then((r) => {
       currentQuantization = [];
       currentQuantization = r.datagons;
-      //currentFilteredQuantization = r.datagons;
       rows = r.rows;
       columns = r.columns;
 


### PR DESCRIPTION
I just noticed that when changing between zoom levels we initially render all hexagons in that layer.
This has now been fixed