### PR TITLE
fix: fix visual summary bugs

### DIFF
--- a/hierarchical-image-explorer/src/components/minis/BarChart.svelte
+++ b/hierarchical-image-explorer/src/components/minis/BarChart.svelte
@@ -24,14 +24,14 @@
   $: spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     description: 'Selection distribution',
-    background: 'transparent',
+    background: null,
     data: {
       values: distribution,
     },
-    mark: { type: 'bar' },
+    mark: 'bar',
     encoding: {
       y: { field: 'category' },
-      x: { field: 'amount', type: 'quantitative' },
+      x: { field: 'amount', type: 'quantitative', axis: { tickMinStep: 1 } },
       color: {
         field: 'category',
         scale: { range: colorscheme },
@@ -40,4 +40,4 @@
   };
 </script>
 
-<VegaLite {spec} />
+<VegaLite {spec} options={{ actions: false }} />

--- a/hierarchical-image-explorer/src/components/minis/BoxPlot.svelte
+++ b/hierarchical-image-explorer/src/components/minis/BoxPlot.svelte
@@ -29,6 +29,7 @@
     title: `Boxplot for ${selectedColumnName}`,
     data: data,
     encoding: { y: { field: 'name', type: 'nominal', title: null } },
+    background: null,
     layer: [
       {
         mark: { type: 'rule' },
@@ -99,5 +100,5 @@
 </script>
 
 <main>
-  <VegaLite {spec} />
+  <VegaLite {spec} options={{ actions: false }} />
 </main>

--- a/hierarchical-image-explorer/src/components/minis/GroupContentDistChart.svelte
+++ b/hierarchical-image-explorer/src/components/minis/GroupContentDistChart.svelte
@@ -142,7 +142,7 @@
             from: { data: 'selectionA' },
             encode: {
               enter: {
-                x: { scale: 'x', field: 'amount' },
+                x: { scale: 'x', field: 'amount', axis: { tickMinStep: 1 } },
                 x2: { scale: 'x', value: 0 },
                 y: { scale: 'y', field: 'label' },
                 height: { scale: 'y', band: 1, offset: -1 },
@@ -193,7 +193,7 @@
             from: { data: 'selectionB' },
             encode: {
               enter: {
-                x: { scale: 'x', field: 'amount' },
+                x: { scale: 'x', field: 'amount', axis: { tickMinStep: 1 } },
                 x2: { scale: 'x', value: 0 },
                 y: { scale: 'y', field: 'label' },
                 height: { scale: 'y', band: 1, offset: -1 },
@@ -212,4 +212,4 @@
   };
 </script>
 
-<Vega {spec} />
+<Vega {spec} options={{ actions: false }} />

--- a/hierarchical-image-explorer/src/components/minis/GroupNumImgChart.svelte
+++ b/hierarchical-image-explorer/src/components/minis/GroupNumImgChart.svelte
@@ -55,4 +55,4 @@
   };
 </script>
 
-<Vega {spec} />
+<Vega {spec} options={{ actions: false }} />

--- a/hierarchical-image-explorer/src/components/minis/GroupView.svelte
+++ b/hierarchical-image-explorer/src/components/minis/GroupView.svelte
@@ -152,17 +152,17 @@
 
 <div class="pl-4 pt-4 font-medium text-lg text-left">Representative images</div>
 <div class="flex flex-row justify-between">
-  <figure>
-    {#if repA !== undefined}
+  {#if repA !== undefined}
+    <figure>
       <img
         alt="selectedA"
         class="ml-4 mt-2 mb-2 w-32 h-32"
         src={BackendService.getImageUrl(repA)}
         style="image-rendering: pixelated;"
       />
-    {/if}
-    <figcaption class="text-center">Group A</figcaption>
-  </figure>
+      <figcaption class="text-center">Group A</figcaption>
+    </figure>
+  {/if}
   {#if repB !== undefined}
     <figure>
       {#if repB !== undefined}

--- a/hierarchical-image-explorer/src/components/minis/Histogram.svelte
+++ b/hierarchical-image-explorer/src/components/minis/Histogram.svelte
@@ -2,7 +2,6 @@
   import type ColumnTable from 'arquero/dist/types/table/column-table';
   import * as aq from 'arquero';
   import { VegaLite } from 'svelte-vega';
-  import { ColorUtil } from '../../services/colorUtil';
 
   export let barColor: string;
   export let selectedRows: ColumnTable;
@@ -46,6 +45,9 @@
   };
 
   $: spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+    description: 'Histogram Visualization',
+    background: null,
     data: data,
     mark: { type: 'bar', fill: barColor, binSpacing: 0, width: { band: 10 } },
     encoding: {
@@ -56,4 +58,4 @@
   };
 </script>
 
-<VegaLite {spec} />
+<VegaLite {spec} options={{ actions: false }} />


### PR DESCRIPTION
Fix a bug where if only cluster B was selected, it was still showing a caption for cluster A below where the representative image would normally be. Also removed all the menus from all Vega visualizations and made sure that some of them display the right scale (in integer steps).